### PR TITLE
fix: require `colorscheme` call to set colorscheme

### DIFF
--- a/colors/fluoromachine.vim
+++ b/colors/fluoromachine.vim
@@ -1,4 +1,4 @@
 lua << EOF
-local fluoromachine = require("fluoromachine")
-fluoromachine.setup({})
+local fluoromachine = require 'fluoromachine'
+fluoromachine.set_colorscheme()
 EOF

--- a/lua/fluoromachine/config.lua
+++ b/lua/fluoromachine/config.lua
@@ -76,8 +76,9 @@ function M:set_brightness()
 end
 
 function M:load(user_config)
-  if vim.tbl_isempty(self.user_config) then
-    self.user_config = user_config or {}
+  -- extend the internal `user_config`. Allows calling `setup` multiple times and changing the current setup
+  if user_config and not vim.tbl_isempty(user_config) then
+    self.user_config = vim.tbl_deep_extend('force', self.user_config, user_config)
   end
 
   self:set_transparent()

--- a/lua/fluoromachine/init.lua
+++ b/lua/fluoromachine/init.lua
@@ -36,7 +36,7 @@ function M:apply_glow()
     return
   end
 
-  if self.user_config.theme == "fluoromachine" or not self.user_config.theme then
+  if self.user_config.theme == 'fluoromachine' or not self.user_config.theme then
     groups.LineNr = { fg = utils.darken(self.colors.purple, 50) }
     groups.CursorLineNr = { fg = self.colors.purple, bold = true }
   end
@@ -65,7 +65,12 @@ function M:apply_glow()
   return groups
 end
 
-M.setup = function(user_config)
+M.set_colorscheme = function()
+  if not M.theme then
+    -- make sure setup is called, `theme` will be `nil` if it hasn't been called yet
+    M.setup()
+  end
+
   if vim.g.colors_name then
     vim.cmd 'hi clear'
   end
@@ -78,8 +83,6 @@ M.setup = function(user_config)
   vim.o.termguicolors = true
   vim.g.colors_name = 'fluoromachine'
 
-  M:load(user_config)
-
   M.theme.set_highlights(M.colors)
 
   if type(M.user_config.overrides) == 'function' then
@@ -89,6 +92,10 @@ M.setup = function(user_config)
   utils.update_highlight_groups(M.user_config.overrides)
   utils.update_highlight_groups(M:apply_glow())
   utils.update_highlight_groups(M:apply_transparency())
+end
+
+M.setup = function(user_config)
+  M:load(user_config)
 end
 
 return M


### PR DESCRIPTION
Currently immediately when you call the `setup` function this plugin sets the colorscheme. This is not ideal if you have already set `:colorscheme` and are working with a configuration with multiple colorschemes. This separates out the `setup` of the user options and the setting of the colors so that you can initialize the plugin without setting the colorscheme. Now the plugin requires `:colorscheme fluoromachine` like any other colorscheme in vim/neovim.


Thanks for such a great theme!